### PR TITLE
chore/dev_options: Disable client restriction per IP

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -496,7 +496,9 @@ impl Client {
             // When there are no more events to process, terminate this thread.
         });
 
-        let action_sender = unwrap!(get_action_sender_rx.recv());
+        let action_sender = get_action_sender_rx.recv().map_err(
+            |_| RoutingError::NotBootstrapped,
+        )?;
 
         Ok(Client {
             interface_result_tx: tx,

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -30,7 +30,7 @@ pub struct Config {
 pub struct DevConfig {
     /// Allow multiple nodes to run on a single machine or LAN
     pub allow_multiple_lan_nodes: bool,
-    /// Disables rate limiting
+    /// Disables rate limiting and disables single client per IP restriction
     pub disable_client_rate_limiter: bool,
     /// Disables requirement to provide a resource proof to bootstrap
     pub disable_resource_proof: bool,


### PR DESCRIPTION
- Disable client restriction per IP based on dev option to disable rate limiter
- Dont unwrap client channel to receive msgs on startup
- Ignore direct messages from recently dropped clients